### PR TITLE
remove OK dialog on artwork write error

### DIFF
--- a/resources/lib/dbupdate.py
+++ b/resources/lib/dbupdate.py
@@ -1208,7 +1208,6 @@ class DBUpdate:
 						xbmcvfs.delete(target)
 						
 				except Exception, (exc):
-					xbmcgui.Dialog().ok(util.localize(32012), util.localize(32011))
 					Logutil.log("Could not create file: '%s'. Error message: '%s'" %(str(fileName), str(exc)), util.LOG_LEVEL_ERROR)
 					return False, artworkurls
 				


### PR DESCRIPTION
on batch runs, this makes the game import at every such error. the operator then needs to wake up, hit enter, and wait for the next error to come up, which is really annoying. the dialog is useless anyways because it doesn't say what the error is, it just says to look in the log... which we can do anyways, without the error message.
